### PR TITLE
i9500: BoardConfig.mk: use xmm7260 additions

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -135,7 +135,7 @@ BOARD_NFC_HAL_SUFFIX := universal5410
 
 # Radio
 BOARD_PROVIDES_LIBRIL := true
-BOARD_MODEM_TYPE := xmm6360
+BOARD_MODEM_TYPE := xmm7260
 BOARD_RIL_CLASS := ../../../device/samsung/i9500/ril
 
 # Wifi


### PR DESCRIPTION
test, mostly OEM_SND related.